### PR TITLE
libm: group with compiler settings

### DIFF
--- a/em1d/Makefile
+++ b/em1d/Makefile
@@ -1,6 +1,7 @@
 # GCC options
 CC = gcc
 CFLAGS = -Ofast -std=c99 -pedantic
+LDFLAGS = -lm
 
 #Debug options
 #CFLAGS = -g -Og -std=c99 -pedantic -fsanitize=undefined -fsanitize=address
@@ -8,13 +9,12 @@ CFLAGS = -Ofast -std=c99 -pedantic
 # Intel icc compiler
 #CC = icc
 #CFLAGS = -restrict -Ofast -std=c99 -pedantic
+#LDFLAGS =
 
 # Clang options
 #CC = clang
 #CFLAGS = -Ofast -std=c99 -pedantic
-
-# On some systems
-LDFLAGS = -lm
+#LDFLAGS = -lm
 
 
 SOURCE = current.c emf.c particles.c random.c timer.c main.c simulation.c zdf.c

--- a/em1ds/Makefile
+++ b/em1ds/Makefile
@@ -1,16 +1,17 @@
 # GCC options
 CC = gcc
 CFLAGS = -Ofast -std=c99 -pedantic
+LDFLAGS = -lm
 
 # Intel icc compiler
 #CC = icc
 #CFLAGS = -restrict -Ofast -std=c99 -pedantic -Wall
+#LDFLAGS =
 
 # Clang options
 #CC = clang
 #CFLAGS = -Ofast -std=c99 -pedantic -Wall
-
-LDFLAGS =
+#LDFLAGS = -lm
 
 
 SOURCE = filter.c charge.c current.c emf.c particles.c grid.c \

--- a/em2d/Makefile
+++ b/em2d/Makefile
@@ -1,17 +1,17 @@
 # GCC options
 CC = gcc
 CFLAGS = -Ofast -std=c99 -pedantic
+LDFLAGS = -lm
 
 # Intel icc compiler
 #CC = icc
 #CFLAGS = -restrict -Ofast -std=c99 -pedantic
+#LDFLAGS =
 
 # Clang options
 #CC = clang
 #CFLAGS = -Ofast
-
-LDFLAGS =
-
+#LDFLAGS = -lm
 
 SOURCE = current.c emf.c particles.c random.c timer.c main.c simulation.c zdf.c
 

--- a/em2ds/Makefile
+++ b/em2ds/Makefile
@@ -1,16 +1,17 @@
 # GCC options
 CC = gcc
 CFLAGS = -Ofast -std=c99 -pedantic
+LDFLAGS = -lm
 
 # Intel icc compiler
 #CC = icc
 #CFLAGS = -restrict -Ofast -std=c99 -pedantic
+#LDFLAGS =
 
 # Clang options
 #CC = clang
 #CFLAGS = -Ofast
-
-LDFLAGS =
+#LDFLAGS = -lm
 
 
 SOURCE = charge.c current.c emf.c particles.c grid2d.c fft.c filter.c random.c timer.c \

--- a/es1d/Makefile
+++ b/es1d/Makefile
@@ -1,16 +1,17 @@
 # GCC options
 CC = gcc
 CFLAGS = -Ofast -std=c99 -pedantic
+LDFLAGS = -lm
 
 # Intel icc compiler
 #CC = icc
 #CFLAGS = -restrict -Ofast -std=c99 -pedantic
+#LDFLAGS =
 
 # Clang options
 # CC = clang
 # CFLAGS = -Ofast -std=c99 -pedantic
-
-LDFLAGS =
+# LDFLAGS = -lm
 
 
 SOURCE = charge.c field.c particles.c grid.c fft.c random.c timer.c main.c simulation.c \

--- a/mods/em1d_param_scan/Makefile
+++ b/mods/em1d_param_scan/Makefile
@@ -1,10 +1,12 @@
 # Non-MPI options
 # CC = gcc
 # CFLAGS = -Ofast -std=c99 -pedantic
+# LDFLAGS = -lm
 
 # MPI options
 CC = mpicc
 CFLAGS = -D_MPI_ -Ofast -std=c99 -pedantic
+LDFLAGS = -lm
 
 
 SOURCE = current.c emf.c particles.c random.c timer.c main.c simulation.c zdf.c

--- a/mods/em1ds_bnd/Makefile
+++ b/mods/em1ds_bnd/Makefile
@@ -1,16 +1,17 @@
 # GCC options
 #CC = gcc-6.3.0
 #CFLAGS = -Ofast -std=c99 -pedantic 
+#LDFLAGS = -lm
 
 # Intel icc compiler
 #CC = icc
 #CFLAGS = -restrict -Ofast -std=c99 -pedantic
+#LDFLAGS =
 
 # Clang options
 CC = clang
 CFLAGS = -Ofast -std=c99 -pedantic
-
-LDFLAGS = 
+LDFLAGS = -lm
 
 
 SOURCE = charge.c current.c emf.c particles.c grid.c fft.c random.c timer.c main.c simulation.c


### PR DESCRIPTION
Update all `Makefile`s to link `libm` (`-lm`) by default. Only `icc`, `cce` and `msvc`/windows do not need to link this since they come with their own, auto-on, optimized math libraries.

Just an idea to switch this on, since GCC seams to be the default compiler in the `Makefile`s. A bit more logic is needed if one wants to disable this in the other cases (e.g. linking `libm` when not needed can also cause linker errors). Yet keeping link flags grouped with the commented compilers might be the way to go as well.