### PR TITLE
Fix Linux Compile of Mods

### DIFF
--- a/mods/em1d_param_scan/main.c
+++ b/mods/em1d_param_scan/main.c
@@ -21,7 +21,11 @@ along with the ZPIC Educational code suite. If not, see <http://www.gnu.org/lice
 #include <stdlib.h>
 #include <math.h>
 #include <unistd.h>
-#include <limits.h>
+#ifdef __linux__
+#   include <linux/limits.h>
+#else
+#   include <limits.h>
+#endif
 
 #ifdef _MPI_
 #include <mpi.h>

--- a/mods/em1ds_bnd/Makefile
+++ b/mods/em1ds_bnd/Makefile
@@ -34,7 +34,7 @@ $(TARGET) : $(OBJ)
 	$(CC)    $(CFLAGS) $(LDFLAGS) $(OBJ) -o $@
 
 .c.o:
-	$(CC) -c $(CFLAGS) $< -o $@
+	$(CC) -I. -c $(CFLAGS) $< -o $@
 
 clean:
 	@touch $(TARGET) $(OBJ)

--- a/mods/em1ds_bnd/fft.h
+++ b/mods/em1ds_bnd/fft.h
@@ -6,6 +6,7 @@
 #ifndef __FFT__
 #define __FFT__
 
+#include "zpic.h"
 #include <complex.h>
 
 #define MAX_FACTORS 32


### PR DESCRIPTION
Fix three compile issues with GCC 7.4.0 on Ubuntu 18.04.3 LTS of the following kinds:
```
fft.c:223:63: error: use of undeclared identifier 'M_PI'

./input/lwfa.c:7:10: fatal error: 'simulation.h' file not found
#include "simulation.h"

main.c: In function ‘run_sim’:
main.c:53:12: error: ‘PATH_MAX’ undeclared (first use in this function); did you mean ‘INT8_MAX’?
  char root[PATH_MAX];
```