### PR TITLE
Update requirements.txt

### DIFF
--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,4 +1,4 @@
-numpy==1.22
+numpy>=1.21.6
 matplotlib==3.5.1
 cython==0.29.26
 ipywidgets==7.6.5


### PR DESCRIPTION
for some reason numpy==1.22 doesn't work currently in binder. 

Had to update to numpy>=1.21.6 for it to build without errors